### PR TITLE
Add CI workflow with tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,33 @@
+name: CI
+
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+
+jobs:
+  lint-test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ['3.11']
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements-test.txt
+      - name: Lint
+        run: |
+          isort --check docker_ctp tests
+          black --check docker_ctp tests
+          ruff check docker_ctp tests
+          mypy docker_ctp tests
+          pydocstyle docker_ctp
+          pylint docker_ctp
+      - name: Tests
+        run: |
+          pytest --cov=docker_ctp --cov-report=term-missing


### PR DESCRIPTION
## Summary
- setup GitHub Actions workflow to run style checks and unit tests
- revert code and test changes so only the workflow is added

## Testing
- `python -m py_compile docker_ctp/*.py`

------
https://chatgpt.com/codex/tasks/task_e_6841d5d5dd80832bbec33b53d6afaf7f